### PR TITLE
Fix Bun install command in production setup script

### DIFF
--- a/scripts/production-setup.sh
+++ b/scripts/production-setup.sh
@@ -34,7 +34,8 @@ fi
 
 # Install Bun
 if ! command -v bun > /dev/null 2>&1; then
-    curl -fsSL https://bun.sh/install | bash -s -- --yes >/dev/null
+    # Install the latest Bun release without arguments
+    curl -fsSL https://bun.sh/install | bash
 
     export BUN_INSTALL="${HOME}/.bun"
     export PATH="${BUN_INSTALL}/bin:$PATH"


### PR DESCRIPTION
## Summary
- remove `--yes` flag from Bun install command in `production-setup.sh`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68644da74d208320aecfbc29bd3cc853