### PR TITLE
Fix package discovery error

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -229,7 +229,8 @@ return [
         'notifiable' => Spatie\Backup\Notifications\Notifiable::class,
 
         'mail' => [
-            'to' => env('DEFAULT_OWNER_EMAIL'),
+            // Ensure a valid email string is always provided
+            'to' => env('DEFAULT_OWNER_EMAIL', env('MAIL_FROM_ADDRESS', '')),
 
             'from' => [
                 'address' => env('MAIL_FROM_ADDRESS'),

--- a/config/secure-headers.php
+++ b/config/secure-headers.php
@@ -487,8 +487,8 @@ return [
             'self' => true,
 
             'allow' => [
-                'https://'.parse_url(env('VITE_ECHO_ADDRESS'), PHP_URL_HOST).(parse_url(env('VITE_ECHO_ADDRESS'), PHP_URL_PORT) === null ? '' : ':'.parse_url(env('VITE_ECHO_ADDRESS'), PHP_URL_PORT)).'/socket.io/',
-                'wss://'.parse_url(env('VITE_ECHO_ADDRESS'), PHP_URL_HOST).(parse_url(env('VITE_ECHO_ADDRESS'), PHP_URL_PORT) === null ? '' : ':'.parse_url(env('VITE_ECHO_ADDRESS'), PHP_URL_PORT)).'/socket.io/',
+                'https://'.parse_url(env('VITE_ECHO_ADDRESS', ''), PHP_URL_HOST).(parse_url(env('VITE_ECHO_ADDRESS', ''), PHP_URL_PORT) === null ? '' : ':'.parse_url(env('VITE_ECHO_ADDRESS', ''), PHP_URL_PORT)).'/socket.io/',
+                'wss://'.parse_url(env('VITE_ECHO_ADDRESS', ''), PHP_URL_HOST).(parse_url(env('VITE_ECHO_ADDRESS', ''), PHP_URL_PORT) === null ? '' : ':'.parse_url(env('VITE_ECHO_ADDRESS', ''), PHP_URL_PORT)).'/socket.io/',
                 'https://api.themoviedb.org/',
             ],
         ],

--- a/scripts/production-setup.sh
+++ b/scripts/production-setup.sh
@@ -34,7 +34,8 @@ fi
 
 # Install Bun
 if ! command -v bun > /dev/null 2>&1; then
-    curl -fsSL https://bun.sh/install | bash -s -- --yes >/dev/null
+    # Install the latest Bun release without arguments
+    curl -fsSL https://bun.sh/install | bash
 
     export BUN_INSTALL="${HOME}/.bun"
     export PATH="${BUN_INSTALL}/bin:$PATH"


### PR DESCRIPTION
## Summary
- cast `VITE_ECHO_ADDRESS` to empty string so parse_url works when unset
- skip `--yes` arg when installing Bun
- use a fallback email in backup config to prevent invalid config errors

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68644da74d208320aecfbc29bd3cc853