### PR TITLE
Fix package discovery error

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -229,7 +229,8 @@ return [
         'notifiable' => Spatie\Backup\Notifications\Notifiable::class,
 
         'mail' => [
-            'to' => env('DEFAULT_OWNER_EMAIL'),
+            // Ensure a valid email string is always provided
+            'to' => env('DEFAULT_OWNER_EMAIL', env('MAIL_FROM_ADDRESS', '')),
 
             'from' => [
                 'address' => env('MAIL_FROM_ADDRESS'),

--- a/config/secure-headers.php
+++ b/config/secure-headers.php
@@ -487,8 +487,8 @@ return [
             'self' => true,
 
             'allow' => [
-                'https://'.parse_url(env('VITE_ECHO_ADDRESS'), PHP_URL_HOST).(parse_url(env('VITE_ECHO_ADDRESS'), PHP_URL_PORT) === null ? '' : ':'.parse_url(env('VITE_ECHO_ADDRESS'), PHP_URL_PORT)).'/socket.io/',
-                'wss://'.parse_url(env('VITE_ECHO_ADDRESS'), PHP_URL_HOST).(parse_url(env('VITE_ECHO_ADDRESS'), PHP_URL_PORT) === null ? '' : ':'.parse_url(env('VITE_ECHO_ADDRESS'), PHP_URL_PORT)).'/socket.io/',
+                'https://'.parse_url(env('VITE_ECHO_ADDRESS', ''), PHP_URL_HOST).(parse_url(env('VITE_ECHO_ADDRESS', ''), PHP_URL_PORT) === null ? '' : ':'.parse_url(env('VITE_ECHO_ADDRESS', ''), PHP_URL_PORT)).'/socket.io/',
+                'wss://'.parse_url(env('VITE_ECHO_ADDRESS', ''), PHP_URL_HOST).(parse_url(env('VITE_ECHO_ADDRESS', ''), PHP_URL_PORT) === null ? '' : ':'.parse_url(env('VITE_ECHO_ADDRESS', ''), PHP_URL_PORT)).'/socket.io/',
                 'https://api.themoviedb.org/',
             ],
         ],

--- a/scripts/production-setup.sh
+++ b/scripts/production-setup.sh
@@ -21,10 +21,21 @@ apt-get update
 apt-get install -y software-properties-common
 add-apt-repository -y ppa:ondrej/php
 apt-get update
+
+# Install required packages without interactive prompts
+export DEBIAN_FRONTEND=noninteractive
+# Allow services to start during installation to avoid dpkg errors
+echo '#!/bin/sh
+exit 0' >/usr/sbin/policy-rc.d
+chmod +x /usr/sbin/policy-rc.d
+
 apt-get install -y nginx mysql-server redis-server git curl unzip nodejs npm \
     php${PHP_VERSION} php${PHP_VERSION}-fpm php${PHP_VERSION}-mysql php${PHP_VERSION}-xml \
     php${PHP_VERSION}-mbstring php${PHP_VERSION}-curl php${PHP_VERSION}-zip \
     php${PHP_VERSION}-bcmath php${PHP_VERSION}-gd php${PHP_VERSION}-intl
+
+# Clean up policy file
+rm -f /usr/sbin/policy-rc.d
 
 
 # Install Composer
@@ -34,7 +45,8 @@ fi
 
 # Install Bun
 if ! command -v bun > /dev/null 2>&1; then
-    curl -fsSL https://bun.sh/install | bash -s -- --yes >/dev/null
+    # Install the latest Bun release without arguments
+    curl -fsSL https://bun.sh/install | bash
 
     export BUN_INSTALL="${HOME}/.bun"
     export PATH="${BUN_INSTALL}/bin:$PATH"


### PR DESCRIPTION
## Summary
- cast `VITE_ECHO_ADDRESS` to empty string so parse_url works when unset
- skip `--yes` arg when installing Bun
- use a fallback email in backup config to prevent invalid config errors
- install packages non-interactively and allow services to start

## Testing
- `bash -n scripts/production-setup.sh`

------
https://chatgpt.com/codex/tasks/task_b_68644da74d208320aecfbc29bd3cc853